### PR TITLE
Use Wayback Availability API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wayback-diff",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "main": "build/app.js",
   "dependencies": {
@@ -19,7 +19,7 @@
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.1.4",
     "react-vis": "^1.11.1",
-    "rollup": "^0.59.2",
+    "rollup": "^0.67.4",
     "rollup-plugin-babel": "^3.0.4",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-image": "^1.0.2",

--- a/src/components/ymd-timestamp-header.jsx
+++ b/src/components/ymd-timestamp-header.jsx
@@ -181,16 +181,15 @@ export default class YmdTimestampHeader extends React.Component {
     if (this.props.fetchSnapshotCallback) {
       return this._handleTimestampValidationFetch(this.props.fetchSnapshotCallback(timestamp), timestamp, fetchedTimestamps, position);
     }
-    const url = handleRelativeURL(this.props.conf.snapshotsPrefix) + timestamp + '/' + encodeURIComponent(this.props.url);
-    return this._handleTimestampValidationFetch(fetch_with_timeout(fetch(url, {redirect: 'follow'})), timestamp, fetchedTimestamps, position);
+    const url = handleRelativeURL(this.props.conf.waybackAvailabilityAPI) + '?url=' + encodeURIComponent(this.props.url) + '&timestamp=' + timestamp;
+    return this._handleTimestampValidationFetch(fetch_with_timeout(fetch(url, {redirect: 'follow', signal: this.ABORT_CONTROLLER.signal})), timestamp, fetchedTimestamps, position);
   }
 
   _handleTimestampValidationFetch (promise, timestamp, fetchedTimestamps, position) {
-    return promise
-      .then(response => {return checkResponse(response);})
-      .then(response => {
-        let url = response.url;
-        fetchedTimestamps[position] = url.split('/')[4];
+    return this._handleFetch(promise)
+      .then(data => {
+        let fetchedTimestamp = data.archived_snapshots.closest.timestamp;
+        fetchedTimestamps[position] = fetchedTimestamp;
         if (timestamp !== fetchedTimestamps[position]) {
           this._redirectToValidatedTimestamps = true;
         }

--- a/src/conf.json
+++ b/src/conf.json
@@ -8,5 +8,6 @@
   "sparklineURL": "http://web.archive.org/__wb/sparkline",
   "iframeLoader": "https://web.archive.org/static/bower_components/wayback-search-js/dist/feb463f3270afee4352651aac697d7e5.gif",
   "waybackDiscoverDiff": "http://localhost:4000",
+  "waybackAvailabilityAPI": "http://archive.org/wayback/available",
   "maxSunburstLevelLength": "70"
 }


### PR DESCRIPTION
As discussed in issue #29 it is not optimal to fetch a capture just so I can validate it's timestamp. This is why with this PR I am using the Wayback Availability API everywhere in the component (both in the YMD-timestamp-header and the Sunburst-container) to validate the timestamps instead of fetching the capture.