### PR TITLE
Drop additional / at removeWBM

### DIFF
--- a/src/components/false-positive-diff-util.jsx
+++ b/src/components/false-positive-diff-util.jsx
@@ -180,7 +180,7 @@ function getWBMCleanURL (element) {
 
 function removeWBM (url){
   let urlArray = url.split('/');
-  urlArray = urlArray.slice(6);
+  urlArray = urlArray.slice(7);
   return urlArray.join('/');
 }
 function removeDiffXPATH (xpath, mode){


### PR DESCRIPTION
This PR pushes a minor fix at the removeWBM method of getTimestampCleanDiff.