### PR TITLE
Use strict_urls parameter of web-monitoring-processing

### DIFF
--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -200,7 +200,7 @@ export default class DiffView extends React.Component {
         .then(data => this.setState({diffData: data}));
     }
     var url = `${this.props.webMonitoringProcessingURL}/`;
-    url += `${diffTypes[diffType].diffService}?format=json&pass_headers=cookie&include=all&a=${a}&b=${b}`;
+    url += `${diffTypes[diffType].diffService}?strict_urls=WBM&format=json&pass_headers=cookie&include=all&a=${a}&b=${b}`;
     fetch_with_timeout(fetch(url, {credentials: 'include'}))
       .then(response => {return checkResponse(response);})
       .then(response => response.json())

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import SandboxedHtml from './sandboxed-html.jsx';
-import {getTimestampCleanDiff} from './false-positive-diff-util.js';
 
 const showRemovals = showType.bind(null, 'removals');
 const showAdditions = showType.bind(null, 'additions');
@@ -29,20 +28,18 @@ export default class SideBySideRenderedDiff extends React.Component {
       transformDeletions = showRemovals;
       transformInsertions = showAdditions;
     }
-    let cleanDiff = getTimestampCleanDiff(this.props.diffData.insertions,
-      this.props.diffData.deletions);
 
     return (
       <div className="side-by-side-render">
         <SandboxedHtml
           iframeLoader={this.props.iframeLoader}
-          html={cleanDiff.deletions || this.props.diffData.diff}
+          html={this.props.diffData.deletions || this.props.diffData.diff}
           baseUrl={this.props.page.url}
           transform={transformDeletions}
         />
         <SandboxedHtml
           iframeLoader={this.props.iframeLoader}
-          html={cleanDiff.insertions || this.props.diffData.diff}
+          html={this.props.diffData.insertions || this.props.diffData.diff}
           baseUrl={this.props.page.url}
           transform={transformInsertions}
         />


### PR DESCRIPTION
This PR uses the strict_urls parameter of web-monitoring-processing to handle the false positive issue instead of the getTimestampCleanDiff function.