### PR TITLE
Use loader prop in iframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,6 @@ The configuration file should have the following format:
   "diffgraphPrefix": "/diffgraph/",
   "cdxServer": "http://web.archive.org/cdx/",
   "sparklineURL": "http://web.archive.org/__wb/sparkline",
-  "iframeLoader": "https://web.archive.org/static/bower_components/wayback-search-js/dist/feb463f3270afee4352651aac697d7e5.gif",
   "waybackDiscoverDiff": "http://localhost:4000",
   "maxSunburstLevelLength": "70",
   "compressedSimhash": true

--- a/src/components/diff-container.jsx
+++ b/src/components/diff-container.jsx
@@ -165,7 +165,7 @@ export default class DiffContainer extends React.Component {
 
       return(<DiffView webMonitoringProcessingURL={handleRelativeURL(this.props.conf.webMonitoringProcessingURL)}
         page={{url: encodeURIComponent(this.props.url)}} diffType={'SIDE_BY_SIDE_RENDERED'} a={urlA} b={urlB}
-        loader={this.props.loader} iframeLoader={this.props.conf.iframeLoader} errorHandledCallback={this.errorHandled}/>);
+        loader={this.props.loader} errorHandledCallback={this.errorHandled}/>);
     }
   }
 

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -129,7 +129,7 @@ export default class DiffView extends React.Component {
     case diffTypes.SIDE_BY_SIDE_RENDERED.value:
       return (
         <SideBySideRenderedDiff diffData={this.state.diffData} page={this.props.page}
-          iframeLoader={this.props.iframeLoader}/>
+          loader={this.props.loader}/>
       );
     case diffTypes.OUTGOING_LINKS.value:
       return (

--- a/src/components/iframe-loader.jsx
+++ b/src/components/iframe-loader.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import _ from 'lodash';
+import Loading from './loading';
+
+
+export default class IframeLoader extends React.PureComponent {
+
+  constructor (props){
+    super(props);
+    this.state = {loaderStyle: null};
+  }
+
+  render () {
+    const Loader = () => _.isNil(this.props.loader)? <Loading/>: this.props.loader;
+    return (
+      <div style={this.state.loaderStyle}>
+        {this.state.loaderStyle? <Loader/>: null}
+      </div>
+    );
+  }
+
+  setLoaderStyle (style) {
+    this.setState({loaderStyle: style});
+  }
+
+
+}

--- a/src/components/sandboxed-html.jsx
+++ b/src/components/sandboxed-html.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import IframeLoader from './iframe-loader';
 
 /**
  * @typedef {Object} SandboxedHtmlProps
@@ -19,13 +20,8 @@ import React from 'react';
 export default class SandboxedHtml extends React.PureComponent {
   constructor (props) {
     super(props);
+    this.loaderRef = React.createRef();
     this._frame = null;
-  }
-
-
-  shouldComponentUpdate(){
-    this.addLoaderImg();
-    return true;
   }
 
   componentDidMount () {
@@ -38,11 +34,13 @@ export default class SandboxedHtml extends React.PureComponent {
   }
 
   render () {
-    return <iframe height={window.innerHeight} onLoad={()=>{this.handleHeight();
-      this.removeLoaderImg();}}
-    sandbox="allow-same-origin allow-forms allow-scripts"
-    ref={frame => this._frame = frame}
-    />;
+    return <div>
+      <iframe height={window.innerHeight} width={'100%'} onLoad={()=>{this.handleHeight(); this.removeLoaderImg();}}
+        sandbox="allow-same-origin allow-forms allow-scripts"
+        ref={frame => this._frame = frame}
+      />
+      <IframeLoader ref={this.loaderRef} loader={this.props.loader}/>
+    </div>;
   }
 
   _updateContent () {
@@ -70,21 +68,14 @@ export default class SandboxedHtml extends React.PureComponent {
   }
 
   removeLoaderImg () {
-    this._frame.loaderImage.parentNode.removeChild(this._frame.loaderImage);
+    this.loaderRef.current.setLoaderStyle(null);
   }
 
   addLoaderImg () {
     let width = this._frame.contentDocument.scrollingElement.offsetWidth;
-
     let centerX = this._frame.offsetLeft + width / 2;
-
-    var elem = document.createElement('img');
-    elem.className = 'waybackDiffIframeLoader';
-    var cssText = 'position:absolute;left:'+centerX+'px;top:50%;';
-    elem.setAttribute('style', cssText);
-    elem.src = this.props.iframeLoader;
-    document.body.appendChild(elem);
-    this._frame.loaderImage = elem;
+    let loaderCSS = {position:'absolute',left:centerX + 'px',top:'50%'};
+    this.loaderRef.current.setLoaderStyle(loaderCSS);
   }
 }
 

--- a/src/components/side-by-side-rendered-diff.jsx
+++ b/src/components/side-by-side-rendered-diff.jsx
@@ -32,13 +32,13 @@ export default class SideBySideRenderedDiff extends React.Component {
     return (
       <div className="side-by-side-render">
         <SandboxedHtml
-          iframeLoader={this.props.iframeLoader}
+          loader={this.props.loader}
           html={this.props.diffData.deletions || this.props.diffData.diff}
           baseUrl={this.props.page.url}
           transform={transformDeletions}
         />
         <SandboxedHtml
-          iframeLoader={this.props.iframeLoader}
+          loader={this.props.loader}
           html={this.props.diffData.insertions || this.props.diffData.diff}
           baseUrl={this.props.page.url}
           transform={transformInsertions}

--- a/src/components/ymd-timestamp-header.jsx
+++ b/src/components/ymd-timestamp-header.jsx
@@ -426,13 +426,6 @@ export default class YmdTimestampHeader extends React.Component {
   }
 
   _showDiffs () {
-
-    let loaders = document.getElementsByClassName('waybackDiffIframeLoader');
-
-    while (loaders.length > 0) {
-      loaders[0].parentNode.removeChild(loaders[0]);
-    }
-
     let timestampAelement = document.getElementById('timestamp-select-left');
     let timestampA = '';
     if (timestampAelement.style.visibility !== 'hidden') {

--- a/src/conf.json
+++ b/src/conf.json
@@ -6,7 +6,6 @@
   "diffgraphPrefix": "/diffgraph/",
   "cdxServer": "http://web.archive.org/cdx/",
   "sparklineURL": "http://web.archive.org/__wb/sparkline",
-  "iframeLoader": "https://web.archive.org/static/bower_components/wayback-search-js/dist/feb463f3270afee4352651aac697d7e5.gif",
   "waybackDiscoverDiff": "http://localhost:4000",
   "maxSunburstLevelLength": "70",
   "compressedSimhash": true


### PR DESCRIPTION
This PR removes the iframeLoader conf option.
Instead of using an image whose source is set in the conf.json we can now use the global Loader component set when instantiating the app. If a Loader prop is not provided, a default fallback is used.