### PR TITLE
Fix ymd text alignment issue

### DIFF
--- a/src/css/diff-container.css
+++ b/src/css/diff-container.css
@@ -40,19 +40,13 @@ blue-diff-footer{
 #timestamp-left{
     display: inline-block;
     float: left;
-    margin-left: 15px;
+    margin-left: 17.8%;
 }
 
 #timestamp-right{
     display: inline-block;
     float: right;
-    margin-right: 15px;
-}
-
-#restart-btn{
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
+    margin-right: 17.8%;
 }
 
 .wayback-ymd-timestamp{
@@ -65,14 +59,20 @@ blue-diff-footer{
 }
 
 .wayback-timestamps {
-    flex: 2 auto;
+    width: 42.86%;
     display: flex;
     flex-flow: row wrap;
     justify-content: center;
 }
 
+.wayback-ymd-buttons > *{
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
 .wayback-ymd-buttons {
-    flex: 1 auto;
+    width: 14.28%;
     display: flex;
     flex-flow: row wrap;
     justify-content: center;


### PR DESCRIPTION
This PR fixes a minor issue where in larger screens the ymd-timestamp text was not correctly aligned. Now the text is placed in the middle of each placeholder.