### PR TITLE
Redirect status

### DIFF
--- a/src/components/diff-container.jsx
+++ b/src/components/diff-container.jsx
@@ -21,20 +21,24 @@ export default class DiffContainer extends React.Component {
   constructor (props) {
     super(props);
     this.state = {
+      showDiff: false,
       timestampA: this.props.timestampA,
       timestampB: this.props.timestampB
     };
     this._oneFrame = null;
     this.errorHandled = this.errorHandled.bind(this);
-    this.changeTimestamps = this.changeTimestamps.bind(this);
+    this.getTimestamps = this.getTimestamps.bind(this);
     this.prepareDiffView = this.prepareDiffView.bind(this);
   }
 
-  changeTimestamps(timestampA, timestampB){
-    window.history.pushState({}, '', this.props.conf.urlPrefix + timestampA + '/' + timestampB + '/' + this.props.url);
+  getTimestamps(timestampA, timestampB){
+    if (timestampA !== this.state.timestampA || timestampB !== this.state.timestampB) {
+      window.history.pushState({}, '', this.props.conf.urlPrefix + timestampA + '/' + timestampB + '/' + this.props.url);
+    }
     this.setState({
       fetchedRaw: null,
       error: null,
+      showDiff: true,
       timestampA: timestampA,
       timestampB: timestampB});
   }
@@ -52,10 +56,10 @@ export default class DiffContainer extends React.Component {
         <ErrorMessage url={this.props.url} code={this.state.error}/>);
     }
     if (!this.state.timestampA && !this.state.timestampB) {
-      if (this.props.noTimestamps){
+      if (this.props.noTimestamps) {
         return (
           <div className="diffcontainer-view">
-            <YmdTimestampHeader {...this.props} changeTimestampsCallback={this.changeTimestamps}
+            <YmdTimestampHeader {...this.props} getTimestampsCallback={this.getTimestamps}
               isInitial={true} errorHandledCallback={this.errorHandled}/>
             {this._showNoTimestamps()}
           </div>);
@@ -64,7 +68,7 @@ export default class DiffContainer extends React.Component {
         <div className="diffcontainer-view">
           <YmdTimestampHeader isInitial={true} {...this.props}
             errorHandledCallback={this.errorHandled}
-            changeTimestampsCallback={this.changeTimestamps}/>
+            getTimestampsCallback={this.getTimestamps}/>
         </div>
       );
     }
@@ -72,18 +76,18 @@ export default class DiffContainer extends React.Component {
       return (
         <div className="diffcontainer-view">
           <YmdTimestampHeader isInitial={false}
-            {...this.props} changeTimestampsCallback={this.changeTimestamps}
+            {...this.props} getTimestampsCallback={this.getTimestamps}
             errorHandledCallback={this.errorHandled}/>
-          {this.prepareDiffView()}
+          {(this.state.showDiff? this.prepareDiffView(): null)}
           <DiffFooter/>
         </div>);
     }
     if (this.state.timestampA) {
       return (
         <div className="diffcontainer-view">
-          <YmdTimestampHeader {...this.props} changeTimestampsCallback={this.changeTimestamps}
+          <YmdTimestampHeader {...this.props} getTimestampsCallback={this.getTimestamps}
             isInitial={false} errorHandledCallback={this.errorHandled}/>
-          {this._showOneSnapshot(true, this.state.timestampA)}
+          {(this.state.showDiff? this._showOneSnapshot(true, this.state.timestampA): null)}
         </div>);
     }
     if (this.state.timestampB) {
@@ -91,8 +95,8 @@ export default class DiffContainer extends React.Component {
         <div className="diffcontainer-view">
           <YmdTimestampHeader isInitial={false} {...this.props}
             errorHandledCallback={this.errorHandled}
-            changeTimestampsCallback={this.changeTimestamps}/>
-          {this._showOneSnapshot(false, this.state.timestampB)}
+            getTimestampsCallback={this.getTimestamps}/>
+          {(this.state.showDiff? this._showOneSnapshot(false, this.state.timestampB): null)}
         </div>);
     }
   }
@@ -107,7 +111,6 @@ export default class DiffContainer extends React.Component {
   }
 
   _showOneSnapshot (isLeft, timestamp) {
-    this._timestampsValidated = true;
     if(this.state.fetchedRaw){
       if (isLeft){
         return(

--- a/src/components/diff-container.jsx
+++ b/src/components/diff-container.jsx
@@ -32,15 +32,33 @@ export default class DiffContainer extends React.Component {
   }
 
   getTimestamps(timestampA, timestampB){
-    if (timestampA !== this.state.timestampA || timestampB !== this.state.timestampB) {
-      window.history.pushState({}, '', this.props.conf.urlPrefix + timestampA + '/' + timestampB + '/' + this.props.url);
+    if (timestampA || timestampB) {
+      if (timestampA && timestampB == null) {
+        timestampB = '';
+        this.setState({
+          fetchedRaw: null,
+          error: null,
+          showDiff: true,
+          timestampA: timestampA});
+      } else if (timestampB && timestampA == null) {
+        timestampA = '';
+        this.setState({
+          fetchedRaw: null,
+          error: null,
+          showDiff: true,
+          timestampB: timestampB});
+      } else {
+        this.setState({
+          fetchedRaw: null,
+          error: null,
+          showDiff: true,
+          timestampA: timestampA,
+          timestampB: timestampB});
+      }
+      if (timestampA !== this.state.timestampA || timestampB !== this.state.timestampB) {
+        window.history.pushState({}, '', this.props.conf.urlPrefix + timestampA + '/' + timestampB + '/' + this.props.url);
+      }
     }
-    this.setState({
-      fetchedRaw: null,
-      error: null,
-      showDiff: true,
-      timestampA: timestampA,
-      timestampB: timestampB});
   }
 
   errorHandled (errorCode) {

--- a/src/components/ymd-timestamp-header.jsx
+++ b/src/components/ymd-timestamp-header.jsx
@@ -209,7 +209,7 @@ export default class YmdTimestampHeader extends React.Component {
     }
   }
 
-  _checkTimestamps () {
+  _checkTimestamps (side = null) {
     this._shouldValidateTimestamp = false;
     var fetchedTimestamps = {a: '', b: ''};
     if (this.state.timestampA && this.state.timestampB) {
@@ -240,6 +240,13 @@ export default class YmdTimestampHeader extends React.Component {
             this.setState({finishedValidating: true});
           }
         }).catch(error => {this._errorHandled(error.message);});
+    } else {
+      if (side === 'left') {
+        this.setState({finishedValidating: true, showLoader: false, leftSnapElements: null, leftSnaps: null});
+      } else if (side === 'right') {
+        this.setState({finishedValidating: true, showLoader: false, rightSnapElements: null, rightSnaps: null});
+      }
+      this.setState({finishedValidating: true, showLoader: false});
     }
   }
 
@@ -352,14 +359,14 @@ export default class YmdTimestampHeader extends React.Component {
                   if (data && data.length > 0) {
                     this._prepareCDXData(leftData, data);
                   } else {
-                    this._checkTimestamps();
+                    this._checkTimestamps('right');
                   }
                 });
             } else {
               this._prepareCDXData(data, null);
             }
           } else {
-            this._checkTimestamps();
+            this._checkTimestamps('left');
           }
         })
         .catch(error => {this._errorHandled(error.message);});
@@ -369,7 +376,7 @@ export default class YmdTimestampHeader extends React.Component {
           if (data && data.length > 0) {
             this._prepareCDXData(null, data);
           } else {
-            this._checkTimestamps();
+            this._checkTimestamps('right');
           }
         });
     }
@@ -390,9 +397,7 @@ export default class YmdTimestampHeader extends React.Component {
     if (leftData) {
       leftData.shift();
     }
-    if (this.state.timestampA && this.state.timestampB) {
-      this.props.getTimestampsCallback(this.state.timestampA, this.state.timestampB);
-    }
+    this.props.getTimestampsCallback(this.state.timestampA, this.state.timestampB);
     this.setState({
       cdxData: true,
       leftSnaps: leftData,
@@ -530,14 +535,14 @@ export default class YmdTimestampHeader extends React.Component {
     if (this._isShowing('timestamp-select-left')) {
       if (this._leftTimestampIndex !== -1) {
         document.getElementById('timestamp-select-left').selectedIndex = this._leftTimestampIndex;
-      } else {
+      } else if (this.state.timestampA){
         document.getElementById('timestamp-select-left').value = this.state.timestampA;
       }
     }
     if (this._isShowing('timestamp-select-right')) {
       if (this._rightTimestampIndex !== -1) {
         document.getElementById('timestamp-select-right').selectedIndex = this._rightTimestampIndex;
-      } else {
+      } else if (this.state.timestampB){
         document.getElementById('timestamp-select-right').value = this.state.timestampB;
       }
     }


### PR DESCRIPTION
This PR aims to fix the issue caused from snapshots that had a redirect, and generally a non-200 status. Since we can't compare those pages I am adding a filter to the CDX queries so as not to display them at all.

In order to do this the execution flow changes a little bit. Instead of the timestamp verification and the request to web-monitoring-processing happening at the same time, after these changes, the request to web-monitoring-processing is made after the timestamp verification so we can guarantee that pages with 200-status code will be compared.