### PR TITLE
Fix CDX server endpoint

### DIFF
--- a/src/components/sunburst/sunburst-container.jsx
+++ b/src/components/sunburst/sunburst-container.jsx
@@ -87,8 +87,7 @@ export default class SunburstContainer extends React.Component {
     if (this.props.fetchSnapshotCallback) {
       promise = this.props.fetchSnapshotCallback(this.props.timestamp);
     } else {
-      let url = new URL(this.props.conf.cdxServer + 'search',
-                        window.location.origin);
+      let url = new URL(this.props.conf.cdxServer, window.location.origin);
       url.searchParams.append('url', this.props.url);
       url.searchParams.append('closest', this.props.timestamp);
       url.searchParams.append('filter', '!mimetype:warc/revisit');

--- a/src/components/timestamp-header.jsx
+++ b/src/components/timestamp-header.jsx
@@ -158,7 +158,7 @@ export default class TimestampHeader extends React.Component {
     if (this.props.fetchCDXCallback) {
       this._handleFetch(this.props.fetchCDXCallback());
     } else {
-      let url = new URL(this.props.conf.cdxServer + 'search', window.location.origin);
+      let url = new URL(this.props.conf.cdxServer, window.location.origin);
       url.searchParams.append('url', this.props.url);
       url.searchParams.append('fl', 'timestamp,digest');
       url.searchParams.append('output', 'json');

--- a/src/components/ymd-timestamp-header.jsx
+++ b/src/components/ymd-timestamp-header.jsx
@@ -254,7 +254,7 @@ export default class YmdTimestampHeader extends React.Component {
     if (this.props.fetchSnapshotCallback) {
       return this._handleTimestampValidationFetch(this.props.fetchSnapshotCallback(timestamp), timestamp, fetchedTimestamps, position);
     }
-    let url = new URL(this.props.conf.cdxServer + 'search', window.location.origin);
+    let url = new URL(this.props.conf.cdxServer, window.location.origin);
     url.searchParams.append('url', this.props.url);
     url.searchParams.append('closest', timestamp);
     url.searchParams.append('filter', '!mimetype:warc/revisit');
@@ -309,7 +309,7 @@ export default class YmdTimestampHeader extends React.Component {
     } else {
       let url;
       if (this._leftMonthIndex !== -1 && !isNaN(this._leftMonthIndex)) {
-        url = new URL(this.props.conf.cdxServer + 'search', window.location.origin);
+        url = new URL(this.props.conf.cdxServer, window.location.origin);
         url.searchParams.append('url', this.props.url);
         url.searchParams.append('fl', 'timestamp,digest');
         url.searchParams.append('output', 'json');
@@ -319,7 +319,7 @@ export default class YmdTimestampHeader extends React.Component {
         leftFetchPromise = this._handleFetch(fetch_with_timeout(fetch(url, {signal: this._abortController.signal})));
       }
       if (this._rightMonthIndex !== -1 && !isNaN(this._rightMonthIndex)) {
-        url = new URL(this.props.conf.cdxServer + 'search', window.location.origin)
+        url = new URL(this.props.conf.cdxServer, window.location.origin);
         url.searchParams.append('url', this.props.url);
         url.searchParams.append('fl', 'timestamp,digest');
         url.searchParams.append('output', 'json');

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ import React from 'react';
 //     pathname = pathname.substring(0, pathname.length - 2);
 //   }
 //   let domain = pathname.split('/').pop();
-//   let url = `${this.conf.cdxServer}search?url=${domain}/&status=200&fl=timestamp,digest&output=json`;
+//   let url = `${this.conf.cdxServer}?url=${domain}/&status=200&fl=timestamp,digest&output=json`;
 //   return fetch(url);
 // }
 


### PR DESCRIPTION
We used to append `search` on CDX server endpoint. This is not
necessary. We define the CDX in conf, there is no need to add something
else in the code, it causes trouble. For instance: when `cdxServer` is
`/web/timemap/cdx`, the final CDX query would be like
`/web/timemap/cdx/search` which doesn't exist.