### PR TITLE
Prevent iframe width from readjusting

### DIFF
--- a/src/components/sandboxed-html.jsx
+++ b/src/components/sandboxed-html.jsx
@@ -56,15 +56,15 @@ export default class SandboxedHtml extends React.PureComponent {
 
   handleHeight () {
     let offsetHeight = this._frame.contentDocument.documentElement.scrollHeight;
-    let offsetWidth = this._frame.contentDocument.documentElement.scrollWidth;
+    // let offsetWidth = this._frame.contentDocument.documentElement.scrollWidth;
     if (offsetHeight > 0.1 * this._frame.height) {
       this._frame.height = offsetHeight + (offsetHeight * 0.01);
     } else {
       this._frame.height = 0.5 * this._frame.height;
     }
-    if (offsetWidth > this._frame.clientWidth) {
-      this._frame.width = offsetWidth;
-    }
+    // if (offsetWidth > this._frame.clientWidth) {
+    //   this._frame.width = offsetWidth;
+    // }
   }
 
   removeLoaderImg () {

--- a/src/components/sandboxed-html.jsx
+++ b/src/components/sandboxed-html.jsx
@@ -56,15 +56,11 @@ export default class SandboxedHtml extends React.PureComponent {
 
   handleHeight () {
     let offsetHeight = this._frame.contentDocument.documentElement.scrollHeight;
-    // let offsetWidth = this._frame.contentDocument.documentElement.scrollWidth;
     if (offsetHeight > 0.1 * this._frame.height) {
       this._frame.height = offsetHeight + (offsetHeight * 0.01);
     } else {
       this._frame.height = 0.5 * this._frame.height;
     }
-    // if (offsetWidth > this._frame.clientWidth) {
-    //   this._frame.width = offsetWidth;
-    // }
   }
 
   removeLoaderImg () {


### PR DESCRIPTION
Allowing each iframe to set its width to its scroll width may cause uneven side-by-side view splits.