### PR TITLE
Pass timestamp as props to ErrorMessage component

### DIFF
--- a/src/components/diff-container.jsx
+++ b/src/components/diff-container.jsx
@@ -73,7 +73,7 @@ export default class DiffContainer extends React.Component {
     }
     if (this.state.error) {
       return (
-        <ErrorMessage url={this.props.url} code={this.state.error}/>);
+        <ErrorMessage url={this.props.url} timestamp={this.state.timestampA} code={this.state.error}/>);
     }
     if (!this.state.timestampA && !this.state.timestampB) {
       if (this.props.noTimestamps) {


### PR DESCRIPTION
If there is any api failure (e.g for me https://gext-api.archive.org/services/diff/html_token?strict_urls=WBM&format=json&pass_[…]%3A%2F%2F0.0.0.0%3A8093%2Fweb%2F20210126193156%2Fiskme.org was returning 502), the error component should be shown.
But in the console it was throwing error like `Uncaught TypeError: Cannot read properties of undefined (reading 'substring')` from https://github.com/internetarchive/wayback-diff/blob/master/src/components/errors.jsx#L31, as there is no prop named as timestamp is passed from diffContainer component.