### PR TITLE
Separate module init and local dev server init

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,62 +46,6 @@ Example request: http://localhost:3000/diff/20170223193029/20171212125810/archiv
 
 Example request: http://localhost:3000/diagram/iskme.org/2018/20180813072115
 
-### Running as a React app
-You must render a DiffContainer component. It can receive up to seven props. See props for more info.
-
-In the **index.js** file the following code should be included:
-
-```Javascript
-import ReactDOM from 'react-dom';
-import DiffContainer from './components/diff-container.jsx';
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-
-
-var conf = require('./conf.json');
-
-ReactDOM.render(
-  <Router>
-  <Switch>
-    <Route path='/diff/([0-9]{14})/([0-9]{14})/(.+)' render={({match, location}) =>
-      <DiffContainer url={match.params[2] + location.search} timestampA={match.params[0]}
-        loader={LOADER_COMPONENT}
-        timestampB={match.params[1]} fetchCDXCallback={null} conf={conf} fetchSnapshotCallback={null} />
-    } />
-    <Route path='/diff/([0-9]{14})//(.+)' render={({match, location}) =>
-      <DiffContainer url={match.params[1] + location.search} timestampA={match.params[0]}
-        loader={LOADER_COMPONENT}
-        fetchCDXCallback={null} conf={conf} fetchSnapshotCallback={null}/>
-    } />
-    <Route path='/diff//([0-9]{14})/(.+)' render={({match, location}) =>
-      <DiffContainer url={match.params[1] + location.search} timestampB={match.params[0]}
-        loader={LOADER_COMPONENT}
-        fetchCDXCallback={null} conf={conf} fetchSnapshotCallback={null}/>
-    } />
-    <Route path='/diff///(.+)' render={({match, location}) =>
-      <DiffContainer url={match.params[0] + location.search} conf={conf} noTimestamps={true}
-      fetchCDXCallback={null} loader={LOADER_COMPONENT}/>
-    } />
-    <Route path='/diff/(.+)' render={({match, location}) =>
-      <DiffContainer url={match.params[0] + location.search} fetchCDXCallback={null}
-        loader={LOADER_COMPONENT} conf={conf}/>}
-    />
-    <Route path='/diffgraph/([0-9]{14})/(.+)' render={({match, location}) =>
-      <SunburstContainer url={match.params[1] + location.search} timestamp={match.params[0]}
-        loader={LOADER_COMPONENT}
-        conf={conf} fetchSnapshotCallback={null}/>} />
-    </Switch>
-  </Router>, document.getElementById('wayback-diff'));
-```
-
-### Use it as a component in an other project
-
-In order to use this app as a component in another React app you should include the following in
-[index.js](https://github.com/internetarchive/wayback-diff/blob/master/src/index.js):
-
-```Javascript
-export DiffContainer from './components/diff-container.jsx';
-export SunburstContainer from './components/sunburst-container.jsx';
-```
 
 #### Props 
 

--- a/config/dev.js
+++ b/config/dev.js
@@ -11,7 +11,7 @@ import cssnano from 'cssnano';
 import { terser } from 'rollup-plugin-terser';
 
 export default {
-  input: 'src/index.js',
+  input: 'src/index-build.js',
   output: {
     name: 'waybackDiff',
     file: 'build/app.js',

--- a/src/index-build.js
+++ b/src/index-build.js
@@ -1,0 +1,2 @@
+export DiffContainer from './components/diff-container.jsx';
+export SunburstContainer from './components/sunburst/sunburst-container.jsx';

--- a/src/index.js
+++ b/src/index.js
@@ -2,71 +2,44 @@
 import React from 'react';
 /* eslint-enable no-unused-vars */
 
-// If on dev uncomment this lines
-// import ReactDOM from 'react-dom';
-// import DiffContainer from './components/diff-container.jsx';
-// import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
-// import SunburstContainer from './components/sunburst/sunburst-container.jsx';
+import ReactDOM from 'react-dom';
+import DiffContainer from './components/diff-container.jsx';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import SunburstContainer from './components/sunburst/sunburst-container.jsx';
 
-// const conf = require('./conf.json');
+const conf = require('./conf.json');
 
-// ReactDOM.render(
-//   <Router>
-//     <Switch>
-//       <Route path='/diff/([0-9]{14})/([0-9]{14})/(.+)' render={({ match, location }) =>
-//         <DiffContainer url={match.params[2] + location.search} timestampA={match.params[0]}
-//           loader={null}
-//           timestampB={match.params[1]} fetchCDXCallback={null} conf={conf} fetchSnapshotCallback={null} />
-//       } />
-//       <Route path='/diff/([0-9]{14})//(.+)' render={({ match, location }) =>
-//         <DiffContainer url={match.params[1] + location.search} timestampA={match.params[0]}
-//           loader={null}
-//           fetchCDXCallback={null} conf={conf} fetchSnapshotCallback={null}/>
-//       } />
-//       <Route path='/diff//([0-9]{14})/(.+)' render={({ match, location }) =>
-//         <DiffContainer url={match.params[1] + location.search} timestampB={match.params[0]}
-//           loader={null}
-//           fetchCDXCallback={null} conf={conf} fetchSnapshotCallback={null}/>
-//       } />
+ReactDOM.render(
+  <Router>
+    <Switch>
+      <Route path='/diff/([0-9]{14})/([0-9]{14})/(.+)' render={({ match, location }) =>
+        <DiffContainer url={match.params[2] + location.search} timestampA={match.params[0]}
+          loader={null}
+          timestampB={match.params[1]} fetchCDXCallback={null} conf={conf} fetchSnapshotCallback={null} />
+      } />
+      <Route path='/diff/([0-9]{14})//(.+)' render={({ match, location }) =>
+        <DiffContainer url={match.params[1] + location.search} timestampA={match.params[0]}
+          loader={null}
+          fetchCDXCallback={null} conf={conf} fetchSnapshotCallback={null}/>
+      } />
+      <Route path='/diff//([0-9]{14})/(.+)' render={({ match, location }) =>
+        <DiffContainer url={match.params[1] + location.search} timestampB={match.params[0]}
+          loader={null}
+          fetchCDXCallback={null} conf={conf} fetchSnapshotCallback={null}/>
+      } />
 
-//       <Route path='/diff///(.+)' render={({ match, location }) =>
-//         <DiffContainer url={match.params[0] + location.search} conf={conf} noTimestamps={true} fetchCDXCallback={null}
-//           loader={null}/>
-//       } />
-//       <Route path='/diff/(.+)' render={({ match, location }) =>
-//         <DiffContainer url={match.params[0] + location.search} fetchCDXCallback={null}
-//           loader={null} conf={conf}/>}
-//       />
-//       <Route path='/diffgraph/([0-9]{14})/(.+)' render={({ match, location }) =>
-//         <SunburstContainer url={match.params[1] + location.search} timestamp={match.params[0]}
-//           loader={null}
-//           conf={conf} fetchSnapshotCallback={null}/>}
-//       />
-//     </Switch>
-//   </Router>, document.getElementById('wayback-diff'));
-
-// function fetchData () {
-//   var pathname = window.location.pathname;
-//   if (pathname[pathname.length - 1] === '/') {
-//     pathname = pathname.substring(0, pathname.length - 2);
-//   }
-//   let domain = pathname.split('/').pop();
-//   let url = `${this.conf.cdxServer}?url=${domain}/&status=200&fl=timestamp,digest&output=json`;
-//   return fetch(url);
-// }
-
-// function fetchSnapshot (timestamp) {
-//   var pathname = window.location.pathname;
-//   if (pathname[pathname.length - 1] === '/') {
-//     pathname = pathname.substring(0, pathname.length - 2);
-//   }
-//   pathname = pathname.split('/');
-//   let domain = pathname.pop();
-//   let url = this.conf.snapshotsPrefix + timestamp + '/' + domain;
-//   console.log('------------This is working! ' + url);
-//   return fetch(url);
-// }
-
-//  If using as a component in an other project uncomment the following line
-export DiffContainer from './components/diff-container.jsx';
-export SunburstContainer from './components/sunburst/sunburst-container.jsx';
+      <Route path='/diff///(.+)' render={({ match, location }) =>
+        <DiffContainer url={match.params[0] + location.search} conf={conf} noTimestamps={true} fetchCDXCallback={null}
+          loader={null}/>
+      } />
+      <Route path='/diff/(.+)' render={({ match, location }) =>
+        <DiffContainer url={match.params[0] + location.search} fetchCDXCallback={null}
+          loader={null} conf={conf}/>}
+      />
+      <Route path='/diffgraph/([0-9]{14})/(.+)' render={({ match, location }) =>
+        <SunburstContainer url={match.params[1] + location.search} timestamp={match.params[0]}
+          loader={null}
+          conf={conf} fetchSnapshotCallback={null}/>}
+      />
+    </Switch>
+  </Router>, document.getElementById('wayback-diff'));


### PR DESCRIPTION
When we write `import DiffContainer from wayback-diff` in wayback-search-js, it checks the main in package.json of wayback-diff package which is `build/app.js`.
I have created another file `index-build.js` and put the only the export statements there, and then change the entry path in `config/dev.js`.
After running yarn build, the `build/app.js` file will be updated.
I have also removed fetchData and fetchSnapshot function which is not in use anymore