### PR TITLE
Deduplicate datetime/timestamp parsing functions

### DIFF
--- a/src/components/timestamp-header.jsx
+++ b/src/components/timestamp-header.jsx
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import '../css/diff-container.css';
-import { fetchWithTimeout, checkResponse } from '../js/utils.js';
+import { fetchWithTimeout, checkResponse, getUTCDateFormat,
+    getShortUTCDateFormat, getYear } from '../js/utils.js';
 /**
  * Display a timestamp selector
  *
@@ -227,12 +228,12 @@ export default class TimestampHeader extends React.Component {
   _prepareOptionElements (data) {
     const initialSnapshots = [];
     if (data.length > 0) {
-      var yearGroup = this._getYear(data[0][0]);
+      var yearGroup = getYear(data[0][0]);
       initialSnapshots.push(<optgroup key={-1} label={yearGroup}/>);
     }
     for (let i = 0; i < data.length; i++) {
-      const utcTime = this._getUTCDateFormat(data[i][0]);
-      const year = this._getYear(data[i][0]);
+      const utcTime = getUTCDateFormat(data[i][0]);
+      const year = getYear(data[i][0]);
       if (year < yearGroup) {
         yearGroup = year;
         initialSnapshots.push(<optgroup key={-i + 2} label={yearGroup}/>);
@@ -240,33 +241,6 @@ export default class TimestampHeader extends React.Component {
       initialSnapshots.push(<option key = {i} value = {data[i][0]}>{utcTime}</option>);
     }
     return initialSnapshots;
-  }
-
-  _getUTCDateFormat (date) {
-    const year = parseInt(date.substring(0, 4), 10);
-    const month = parseInt(date.substring(4, 6), 10) - 1;
-    const day = parseInt(date.substring(6, 8), 10);
-    const hour = parseInt(date.substring(8, 10), 10);
-    const minutes = parseInt(date.substring(10, 12), 10);
-    const seconds = parseInt(date.substring(12, 14), 10);
-
-    const niceTime = new Date(Date.UTC(year, month, day, hour, minutes, seconds));
-    return (niceTime.toUTCString());
-  }
-
-  _getShortUTCDateFormat (date) {
-    const year = parseInt(date.substring(0, 4), 10);
-    const month = parseInt(date.substring(4, 6), 10) - 1;
-    const day = parseInt(date.substring(6, 8), 10);
-    let shortTime = new Date(Date.UTC(year, month, day));
-    shortTime = shortTime.toUTCString();
-    shortTime = shortTime.split(' ');
-    const retTime = shortTime[0] + ' ' + shortTime[1] + ' ' + shortTime[2] + ' ' + shortTime[3];
-    return (retTime);
-  }
-
-  _getYear (date) {
-    return parseInt(date.substring(0, 4), 10);
   }
 
   _restartPressed () {
@@ -352,8 +326,8 @@ export default class TimestampHeader extends React.Component {
 
   _getHeaderInfo (data) {
     if (data) {
-      const first = this._getShortUTCDateFormat(data[0][0]);
-      const last = this._getShortUTCDateFormat(data[data.length - 1][0]);
+      const first = getShortUTCDateFormat(data[0][0]);
+      const last = getShortUTCDateFormat(data[data.length - 1][0]);
       const numberWithCommas = (x) => {
         return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
       };

--- a/src/components/ymd-timestamp-header.jsx
+++ b/src/components/ymd-timestamp-header.jsx
@@ -2,7 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import '../css/diff-container.css';
 import {
-  fetchWithTimeout, getTwoDigitInt, getKeyByValue, selectHasValue, getUTCDateFormat
+  fetchWithTimeout, getTwoDigitInt, getKeyByValue, selectHasValue,
+  getUTCDateFormat, getShortUTCDateFormat
 } from '../js/utils.js';
 import Loading from './loading.jsx';
 import isNil from 'lodash/isNil';
@@ -459,15 +460,6 @@ export default class YmdTimestampHeader extends React.Component {
     }
   }
 
-  /** Input: "20190504221015" Output: "Sat, 04 May 2019" */
-  _getShortUTCDateFormat (timestamp) {
-    const year = parseInt(timestamp.substring(0, 4), 10);
-    const month = parseInt(timestamp.substring(4, 6), 10) - 1;
-    const day = parseInt(timestamp.substring(6, 8), 10);
-    const utcDateTime = new Date(Date.UTC(year, month, day));
-    return utcDateTime.toUTCString().split(' ').slice(0, 4).join(' ');
-  }
-
   _restartPressed () {
     this.setState({
       showRestartBtn: false,
@@ -589,8 +581,8 @@ export default class YmdTimestampHeader extends React.Component {
   }
 
   _getHeaderInfo (firstTimestamp, lastTimestamp, count) {
-    const first = this._getShortUTCDateFormat(firstTimestamp);
-    const last = this._getShortUTCDateFormat(lastTimestamp);
+    const first = getShortUTCDateFormat(firstTimestamp);
+    const last = getShortUTCDateFormat(lastTimestamp);
     return (<p id='explanation-middle'> Compare any two captures of {this.props.url} from our collection
       of {count.toLocaleString()} dating from {first} to {last}.</p>);
   }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -165,6 +165,19 @@ export function getUTCDateFormat (date) {
   return (niceTime.toUTCString());
 }
 
+/** Input: "20190504221015" Output: "Sat, 04 May 2019" */
+export function getShortUTCDateFormat (timestamp) {
+  const year = parseInt(timestamp.substring(0, 4), 10);
+  const month = parseInt(timestamp.substring(4, 6), 10) - 1;
+  const day = parseInt(timestamp.substring(6, 8), 10);
+  const utcDateTime = new Date(Date.UTC(year, month, day));
+  return utcDateTime.toUTCString().split(' ').slice(0, 4).join(' ');
+}
+
+export function getYear (ts) {
+  return parseInt(ts.substring(0, 4), 10);
+}
+
 export function b64ToArray (b64Data) {
   const byteCharacters = atob(b64Data);
   const byteNumbers = new Array(byteCharacters.length);


### PR DESCRIPTION
Move them to `utils.js` and drop duplicates in components
`YmdTimestampHeader` and `TimestampHeader`.