### PR TITLE
Update node from 14 to 16 in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/wayback-diff
     docker:
-      - image: circleci/node:14.17.1
+      - image: circleci/node:16.16.0
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Fix issue:
```
error rollup@3.19.1: The engine "node" is incompatible with this module. Expected version ">=14.18.0". Got "14.17.1"
```