### PR TITLE
Revert "CircleCI: Migrating to next-gen Convenience Images"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/wayback-diff
     docker:
-      - image: cimg/node:20
+      - image: circleci/node:16.13.0
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Reverts internetarchive/wayback-diff#157 because

```
Starting container cimg/node:20
Warning: No authentication provided, using CircleCI credentials for pulls from Docker Hub.
  image cache not found on this host, downloading cimg/node:20

Error response from daemon: manifest for cimg/node:20 not found: manifest unknown: manifest unknown
```