### PR TITLE
Redo #157:  CircleCI: Migrating to next-gen Convenience Images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/wayback-diff
     docker:
-      - image: circleci/node:16.13.0
+      - image: cimg/node:20.6
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
* https://hub.docker.com/r/cimg/node/tags -- `cimg/node:20.6` with the `.6` being mandatory.
* https://github.com/internetarchive/wayback-diff/pull/157#issuecomment-1706481097