### PR TITLE
CircleCI: Use Docker image cimg/node:16.13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/wayback-diff
     docker:
-      - image: cimg/node:20.6
+      - image: cimg/node:16.13.0
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
[cimg/node:16.13.0](https://hub.docker.com/layers/cimg/node/16.13.0/images/sha256-05245e5a0f7aa7c45d61c21ba47c13082bdc07efe555a6786087261b28adaa2b)

* #157
* #158
* #159