### PR TITLE
CircleCI: Upgrade Node.js from 16.13.0 to 16.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: ~/wayback-diff
     docker:
-      - image: cimg/node:16.13.0
+      - image: cimg/node:16.20
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Test on Docker image [cimg/node:16.20](https://hub.docker.com/layers/cimg/node/16.20/images/sha256-728cf88099777a6b4a9f9bd958b91b9ad75edb610cbae1bd80e9232725d32055?context=explore)