### PR TITLE
Add configs for pdf-diff server and pdf diffType + Add condition to c…

### DIFF
--- a/src/components/diff-container.jsx
+++ b/src/components/diff-container.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import DiffView from './diff-view.jsx';
+import { diffTypesFor } from '../js/constants/diff-types';
 import '../css/diff-container.css';
 import YmdTimestampHeader from './ymd-timestamp-header.jsx';
 import DiffFooter from './footer.jsx';
@@ -150,10 +151,16 @@ export default class DiffContainer extends React.Component {
     if (!this.state.error) {
       const urlA = new URL(conf.snapshotsPrefix + timestampA + '/' + encodeURIComponent(url), window.location.origin);
       const urlB = new URL(conf.snapshotsPrefix + timestampB + '/' + encodeURIComponent(url), window.location.origin);
-      const webMonURL = new URL(conf.webMonitoringProcessingURL, window.location.origin);
-      return (<DiffView webMonitoringProcessingURL={webMonURL.toString()}
+      const ext = '.' + url.split('.').pop();
+      const availableTypes = diffTypesFor(ext);
+      const isPdf = availableTypes.length > 0 && ext === '.pdf';
+      const diffType = availableTypes.length > 0 ? availableTypes[0].value : 'SIDE_BY_SIDE_RENDERED';
+      const backendURL = isPdf
+        ? new URL(conf.pdfMonitoringProcessingURL, window.location.origin)
+        : new URL(conf.webMonitoringProcessingURL, window.location.origin);
+      return (<DiffView webMonitoringProcessingURL={backendURL.toString()}
         page={{ url: encodeURIComponent(url) }}
-        diffType={'SIDE_BY_SIDE_RENDERED'} a={urlA} b={urlB}
+        diffType={diffType} a={urlA} b={urlB}
         loader={loader} errorHandledCallback={this.errorHandled}/>);
     }
   };

--- a/src/components/diff-view.jsx
+++ b/src/components/diff-view.jsx
@@ -128,6 +128,7 @@ export default class DiffView extends React.Component {
         <InlineRenderedDiff diffData={this.state.diffData} page={this.props.page} />
       );
     case diffTypes.SIDE_BY_SIDE_RENDERED.value:
+    case diffTypes.PDF_SIDE_BY_SIDE_RENDERED.value:
       return (
         <SideBySideRenderedDiff diffData={this.state.diffData} page={this.props.page}
           loader={this.props.loader}/>

--- a/src/conf.json
+++ b/src/conf.json
@@ -1,5 +1,6 @@
 {
   "webMonitoringProcessingURL": "http://localhost:8888",
+  "pdfMonitoringProcessingURL": "http://localhost:8889",
   "limit": "1000",
   "snapshotsPrefix": "http://web.archive.org/web/",
   "urlPrefix": "/diff/",

--- a/src/js/constants/diff-types.js
+++ b/src/js/constants/diff-types.js
@@ -42,6 +42,10 @@ export const diffTypes = {
   CHANGES_ONLY_SOURCE: {
     description: 'Changes Only Source',
     diffService: 'html_source_dmp'
+  },
+  PDF_SIDE_BY_SIDE_RENDERED: {
+    description: 'Side-by-Side Rendered for PDF',
+    diffService: 'pdf_rendered'
   }
 };
 
@@ -69,6 +73,10 @@ const diffTypesByMediaType = {
     diffTypes.RAW_SIDE_BY_SIDE,
     diffTypes.RAW_FROM_CONTENT,
     diffTypes.RAW_TO_CONTENT
+  ],
+
+  'application/pdf': [
+    diffTypes.PDF_SIDE_BY_SIDE_RENDERED
   ]
 };
 


### PR DESCRIPTION
## Overview
We want to add support for PDF diff. This involves implementing a backend server to handle diff operations between PDF(s). The frontend needs to check `mediaType` and route the request to the appropriate backend server with the correct `diffType`.

## Change (breakable)
- Add a new attribute in `conf.json` to point to the correct server endpoint (I assume this config is overwritten in prod env, thus, that prod config needs to be updated with this attribute as well)
- Add new `DiffType`
- Add conditions to route to request to the correct server with the correct `diffType`